### PR TITLE
Fix environment variable name in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
   - '--memory=2Gi'
   - '--timeout=900s'
   - '--set-env-vars'
-  - 'BQ_DATASET=marketing_ml,BQ_TABLE=click_revenue,MODEL_BUCKET=ltv-models'
+  - 'BQ_DATASET=marketing_ml,CLICKS_TABLE=click_revenue,MODEL_BUCKET=ltv-models'
 
 # ────────────────────────────────
 # 3. Deploy Cloud Function (upload_ltv)


### PR DESCRIPTION
## Summary
- change the env var name from `BQ_TABLE` to `CLICKS_TABLE` in the Cloud Run deployment step

## Testing
- `python -m py_compile train_and_score.py upload_ltv.py`

------
https://chatgpt.com/codex/tasks/task_e_686476256290832996e601ae2896c740