### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+*.pyc
+__pycache__/


### PR DESCRIPTION
## Summary
- add a `.dockerignore` file to keep unwanted files out of the build context

## Testing
- `python -m py_compile train_and_score.py upload_ltv.py`
- `docker build -t test-image .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686476277f008329ab16a02f3076870b